### PR TITLE
NAS-116667 / 13.0 / Build hpt27xx, hptnr and hptrr as modules. (by amotin)

### DIFF
--- a/build/profiles/freenas/config.pyd
+++ b/build/profiles/freenas/config.pyd
@@ -94,7 +94,10 @@ kernel_modules = [
     "fxp",
     "ice_ddp",
     "sis",
+    "hpt27xx",
     "hptmv",
+    "hptnr",
+    "hptrr",
 ]
 
 # World/kernel build configuration


### PR DESCRIPTION
I've missed when they were removed from GENERIC in 13, while some
people are still using at least hptnr.

Ticket:	NAS-116667

Original PR: https://github.com/truenas/core-build/pull/295
Jira URL: https://jira.ixsystems.com/browse/NAS-116667