### PR TITLE
NAS-117679 / 13.0 / Add hidbus module for usbhid devices (by freqlabs)

### DIFF
--- a/build/profiles/freenas/config.pyd
+++ b/build/profiles/freenas/config.pyd
@@ -48,6 +48,7 @@ kernel_modules = [
     "ext2fs",
     "firewire",
     "geom",
+    "hidbus",
     "i2c",
     "ipmi",
     "ipsec",


### PR DESCRIPTION
usbhid(4) is brought in with the usb(4) driver, but depends on
hidbus(4) which we do not currently build.  Some keyboards are USB HID
class devices, so this is useful to have.

Original PR: https://github.com/truenas/core-build/pull/300
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117679