### PR TITLE
NAS-117679 / 13.1 / Fix build after previous commit.

### DIFF
--- a/build/profiles/freenas/config.pyd
+++ b/build/profiles/freenas/config.pyd
@@ -48,7 +48,7 @@ kernel_modules = [
     "ext2fs",
     "firewire",
     "geom",
-    "hidbus",
+    "hid",
     "i2c",
     "ipmi",
     "ipsec",


### PR DESCRIPTION
hidbus module has to be specified as hid/hidbus.  But to make this
hid code useful lets include all the hid modules, not only the bus.