### PR TITLE
NAS-117679 / 13.0 / Fix build after previous commit. (by amotin)

### DIFF
--- a/build/profiles/freenas/config.pyd
+++ b/build/profiles/freenas/config.pyd
@@ -48,7 +48,7 @@ kernel_modules = [
     "ext2fs",
     "firewire",
     "geom",
-    "hidbus",
+    "hid",
     "i2c",
     "ipmi",
     "ipsec",


### PR DESCRIPTION
hidbus module has to be specified as hid/hidbus.  But to make this
hid code useful lets include all the hid modules, not only the bus.

Original PR: https://github.com/truenas/core-build/pull/302
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117679