### PR TITLE
Fix ports building on FreeBSD 13.3

### DIFF
--- a/build/profiles/freenas/ports-system.pyd
+++ b/build/profiles/freenas/ports-system.pyd
@@ -74,7 +74,7 @@ ports += {
 ports += "misc/cpuid"
 ports += "net-mgmt/clog"
 ports += "net/mosh"
-ports += "net/wireguard"
+ports += "net/wireguard-tools"
 ports += "net-mgmt/sipcalc"
 
 ports += "security/cyrus-sasl2-gssapi"
@@ -110,10 +110,6 @@ ports += {
 }
 ports += "lang/python3"
 ports += "lang/python"
-ports += {
-    "name": "lang/python39-debugging",
-    "install": False,
-}
 ports += "sysutils/scanlnk"
 ports += "sysutils/iocage"
 ports += "security/pam_mkhomedir"
@@ -169,7 +165,10 @@ ports += {
 }
 ports += {
     "name": "sysutils/nut",
-    "options": ["OPTIONS_FILE_UNSET+=NEON"]
+    "options": [
+        "OPTIONS_FILE_UNSET+=NEON",
+        "OPTIONS_FILE_SET+=DEV"
+    ],
 }
 #ports += "devel/gio-fam-backend"
 ports += "sysutils/jailme"
@@ -227,8 +226,12 @@ ports += "sysutils/megacli"
 ports += "sysutils/areca-cli"
 ports += "sysutils/hptcli"
 ports += {
-    "name": "net/py-ldap",
+    "name": "net/py-python-ldap",
     "options": ["OPTIONS_FILE_SET+=SASL"]
+}
+ports += {
+    "name": "dns/py-dnspython",
+    "options": ["OPTIONS_FILE_UNSET+=DOQ"]
 }
 ports += {
     "name": "devel/dbus",
@@ -324,7 +327,7 @@ ports += "misc/xtail"
 ports += "sysutils/edk2@bhyve"
 ports += "benchmarks/fio"
 ports += "sysutils/cmdwatch"
-ports += "sysutils/devcpu-data"
+ports += "sysutils/cpu-microcode"
 ports += "sysutils/htop"
 ports += "sysutils/mcelog"
 ports += {

--- a/build/profiles/freenas/ports-system.pyd
+++ b/build/profiles/freenas/ports-system.pyd
@@ -44,7 +44,6 @@ ports += {
 ports += "security/stunnel"
 ports += "comms/lrzsz"
 ports += "sysutils/kiconvtool"
-ports += "sysutils/screen"
 ports += "sysutils/iohyve"
 ports += "sysutils/vm-bhyve"
 ports += "sysutils/pciutils"

--- a/build/profiles/freenas/repos.pyd
+++ b/build/profiles/freenas/repos.pyd
@@ -34,7 +34,7 @@ repos += {
     "name": "freenas",
     "path": "freenas",
     "url": "http://github.com/freenas/freenas.git",
-    "branch": "truenas/13.1-stable"
+    "branch": "truenas/13.3-stable"
 }
 
 
@@ -49,7 +49,7 @@ repos += {
     "name": "ports",
     "path": "ports",
     "url": "https://github.com/freenas/ports.git",
-    "branch": "truenas/13.1-stable"
+    "branch": "truenas/13.3-stable"
 }
 
 repos += {


### PR DESCRIPTION
Various ports have been renamed, this is addressed in the current PR.

python-dns by default builds with asnyc QUIC support which brings in a rust dependency. Since we don't use QUIC for middleware, it's safe to remove and avoid building rust.

The python debugging package is currently removed due to build failure caused by sharing same
distfile with the default python package. This will require redesign if it is to be included in 13.3-release.