### PR TITLE
NAS-128694 / 13.3 / Add wireguard kernel driver

### DIFF
--- a/build/profiles/freenas/config.pyd
+++ b/build/profiles/freenas/config.pyd
@@ -50,6 +50,7 @@ kernel_modules = [
     "geom",
     "hid",
     "i2c",
+    "if_wg",
     "ipmi",
     "ipsec",
     "iscsi",


### PR DESCRIPTION
This was added back to kernel in FreeBSD 13.2